### PR TITLE
Add CORS support for JWT endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 import os
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.api.router import api_router
 from app.core.database import Base, engine
 from app.job import scheduler
@@ -7,6 +8,15 @@ from app.job import scheduler
 Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 base_router = os.getenv("BASE_ROUTER", "")
 app.include_router(api_router, prefix=f"/{base_router}/api")
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -42,6 +42,18 @@ def test_jwt_token():
     assert decoded["userSn"] == "test-user"
 
 
+def test_cors_headers():
+    response = client.options(
+        f"/{os.getenv('BASE_ROUTER')}/api/public/v1/jwt",
+        headers={
+            "Origin": "http://localhost:8001",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:8001"
+
+
 @pytest.mark.parametrize(
     "url,expected",
     [


### PR DESCRIPTION
## Summary
- enable CORS on the FastAPI app to accept cross-origin requests
- add test ensuring the JWT endpoint sends CORS headers

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892078d61208329820738a737605aa5