### PR TITLE
feat: add async generation workflow

### DIFF
--- a/backend/app/mq/handlers/llm_handler.py
+++ b/backend/app/mq/handlers/llm_handler.py
@@ -1,0 +1,61 @@
+import json
+import os
+from langchain_openai import ChatOpenAI
+from langchain.prompts import ChatPromptTemplate
+from sqlalchemy import create_engine, text
+from app.core.config import settings
+
+engine = create_engine(settings.database_url)
+
+
+def get_title_optimize_chain():
+    prompt = ChatPromptTemplate.from_template(
+        "你是一個郵件行銷助手，請根據內容優化標題並判斷情感與是否為垃圾訊息。"
+        "以 JSON 格式回傳，包含 title, sentiment, is_spam。內容: {content}"
+    )
+    llm = ChatOpenAI(
+        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+        temperature=0,
+        api_key=os.getenv("OPENAI_API_KEY"),
+    )
+    return prompt | llm
+
+
+chain_map = {
+    "title_optimize": get_title_optimize_chain(),
+}
+
+
+def handle_llm_task(message: str) -> None:
+    data = json.loads(message)
+    chain = chain_map.get(data.get("magicType"))
+    if chain is None:
+        return
+    raw = chain.invoke({"content": data.get("content", "")}).content
+    result = json.loads(raw)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS magic_task_results (
+                    campaign_sn TEXT,
+                    magic_type TEXT,
+                    result JSONB
+                )
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO magic_task_results (campaign_sn, magic_type, result)
+                VALUES (:campaign_sn, :magic_type, :result::jsonb)
+                """
+            ),
+            {
+                "campaign_sn": data.get("campaignSn"),
+                "magic_type": data.get("magicType"),
+                "result": json.dumps(result),
+            },
+        )
+

--- a/k8s/backend-deployment.yaml
+++ b/k8s/backend-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: your-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+      - name: backend
+        image: your-registry/backend:latest
+        imagePullPolicy: Always
+        env:
+        - name: KAFKA_BOOTSTRAP_SERVERS
+          value: kafka:9092
+        - name: KAFKA_TOPIC
+          value: magic-task
+        - name: DATABASE_URL
+          value: postgresql://user:password@pg:5432/yourdb
+        - name: JWT_SECRET
+          value: secret
+        ports:
+        - containerPort: 8000

--- a/k8s/llm-worker-config.yaml
+++ b/k8s/llm-worker-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-worker-config
+  namespace: your-namespace
+data:
+  KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+  KAFKA_TOPIC: magic-task
+  POSTGRES_URL: postgresql://user:password@pg:5432/yourdb
+  OPENAI_API_KEY: sk-xxx
+  OPENAI_MODEL: gpt-4o-mini

--- a/k8s/llm-worker-deployment.yaml
+++ b/k8s/llm-worker-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-worker
+  namespace: your-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm-worker
+  template:
+    metadata:
+      labels:
+        app: llm-worker
+    spec:
+      containers:
+      - name: llm-worker
+        image: your-registry/llm-worker:latest
+        imagePullPolicy: Always
+        envFrom:
+        - configMapRef:
+            name: llm-worker-config
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "512Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10

--- a/spec/2025-08-07-kafka-task-and-llm.md
+++ b/spec/2025-08-07-kafka-task-and-llm.md
@@ -1,0 +1,174 @@
+# Feature: Kafka 任務處理與 GPT 呼叫流程建置
+
+## 背景（Business Context）
+
+為實現使用者非同步內容分析功能，系統需支援從 `/generate` 發送請求至 Kafka，再由 LLM Worker 處理並透過 LangChain 呼叫 GPT-4o Mini，最終將結果寫入 PostgreSQL。
+
+## 使用者故事（User Story）
+
+作為【開發者】
+
+我希望在 /generate API 中推送任務至 Kafka
+
+並由 Worker 使用 LangChain 呼叫 GPT 處理，結果寫入資料庫
+
+以便實現穩定、可擴展的 AI 分析流程
+
+## 驗收條件（Acceptance Criteria）
+
+- [ ]  FastAPI 實作 `/api/public/v1/generate`，驗證 JWT 後推送任務至 Kafka
+- [ ]  建立 LLM Worker，可從 Kafka 消費任務並處理內容
+- [ ]  Worker 使用 LangChain 封裝 prompt 並呼叫 GPT-4o Mini
+- [ ]  GPT 回應結果為 JSON 格式（含標題優化、情感、是否垃圾訊息）
+- [ ]  Worker 將處理結果寫入 PostgreSQL
+- [ ]  撰寫 backend 與 worker 的初版 Kubernetes YAML 檔案
+
+## 輸入資料（Inputs）
+
+### /generate 請求範例
+
+```json
+{
+  "campaignSn": "abc123",
+  "magicType": "title_optimize",
+  "content": "限時下殺！買一送一活動開跑啦，快邀朋友一起搶購！"
+}
+```
+
+### JWT 驗證格式（Authorization Header）
+
+```
+Authorization: Bearer <your-jwt-token>
+```
+
+### GPT 回應格式範例
+
+```json
+{
+  "title": "買一送一限時優惠，快邀好友一起搶購！",
+  "sentiment": "positive",
+  "is_spam": false
+}
+```
+
+---
+
+若未來你要加入多種 `magicType` 對應不同的 LangChain Chain，可以擴充 `Worker` 的處理邏輯。是否需要也列為延伸功能？
+
+## 延伸功能（Future Enhancements）
+
+### 🎯 支援多種 `magicType` 對應不同的 LLM Chain 任務
+
+為滿足更多 AI 處理需求，系統將擴充不同 `magicType` 類型的處理能力，例如標題優化、情感分析、垃圾郵件判斷等，並透過模組化設計拆分對應的 LangChain Chain。
+
+### 範例 magicType 對應表
+
+| magicType | 功能描述 | 對應 Chain 函式 |
+| --- | --- | --- |
+| `title_optimize` | 優化標題文案 | `get_title_optimize_chain()` |
+| `sentiment_detect` | 分析內容情緒傾向 | `get_sentiment_chain()` |
+| `spam_check` | 判斷是否為垃圾訊息 | `get_spam_check_chain()` |
+| `sku_mapping` | 商品描述對應 SKU（RAG） | `get_rag_chain_to_sku()` |
+
+### Chain 設計原則
+
+- 每個 `magicType` 對應一個專屬的 LangChain Chain
+- Chain 輸入統一為：`{"content": str, ...}`
+- 輸出皆為結構化 JSON，方便入庫
+- 可透過 `magicType -> chain_map` 的方式切換調用
+
+### 範例 chain_map 撰寫方式
+
+```python
+chain_map = {
+    "title_optimize": get_title_optimize_chain(),
+    "sentiment_detect": get_sentiment_chain(),
+    "spam_check": get_spam_check_chain(),
+    "sku_mapping": get_rag_chain_to_sku()
+}
+
+selected_chain = chain_map[data["magicType"]]
+result = selected_chain.invoke({"content": data["content"]})
+```
+
+## 🧩 Kubernetes ConfigMap（環境參數設定）
+
+```yaml
+# k8s/llm-worker-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llm-worker-config
+  namespace: your-namespace
+data:
+  KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+  KAFKA_TOPIC: magic-task
+  POSTGRES_URL: postgresql://user:password@pg:5432/yourdb
+  OPENAI_API_KEY: sk-xxx
+  OPENAI_MODEL: gpt-4o-mini
+```
+
+---
+
+## 🚀 Kubernetes Deployment
+
+```yaml
+# k8s/llm-worker-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-worker
+  namespace: your-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm-worker
+  template:
+    metadata:
+      labels:
+        app: llm-worker
+    spec:
+      containers:
+      - name: llm-worker
+        image: your-registry/llm-worker:latest
+        imagePullPolicy: Always
+        envFrom:
+        - configMapRef:
+            name: llm-worker-config
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "512Mi"
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+```
+
+---
+
+## 📄 ConfigMap + YAML 設計原則摘要
+
+| 類型 | 說明 |
+| --- | --- |
+| `ConfigMap` | 集中管理 Kafka、PostgreSQL、OpenAI 金鑰與模型名稱等參數 |
+| `Deployment` | 啟動 worker 容器，從 Kafka 消費並使用 LangChain 處理 |
+| `Probe` | 建議提供 `/healthz` endpoint 讓 K8s 監測健康狀態，避免 Pod 卡死 |
+| `envFrom` | 使用 ConfigMap 簡化環境變數注入 |
+| `resources` | 初步設置適度資源，避免佔用整個節點，可後續依 GPT latency 調整 |
+
+---
+
+若你使用 **Secret** 儲存 API Key，可以將 `OPENAI_API_KEY` 移到 Secret，再透過 `envFrom: secretRef` 注入。


### PR DESCRIPTION
## Summary
- queue `/generate` requests to Kafka after JWT validation
- add LLM worker using LangChain and OpenAI to process Kafka tasks and store results
- provide initial Kubernetes manifests for backend and worker
- refactor worker implementation into MQ handler for message processing
- remove unused worker requirements file

## Testing
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892c11649b0832998c3f6c8b9b14b10