### PR TITLE
refactor: add service for magic task results

### DIFF
--- a/backend/app/mq/handlers/llm_handler.py
+++ b/backend/app/mq/handlers/llm_handler.py
@@ -4,8 +4,7 @@ import os
 from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 
-from app.core.database import AsyncSessionLocal
-from app.models.magic_task_result import MagicTaskResult
+from app.services.magic_task_result_service import create_magic_task_result
 
 
 def get_title_optimize_chain():
@@ -33,13 +32,8 @@ async def handle_llm_task(message: str) -> None:
         return
     raw = (await chain.ainvoke({"content": data.get("content", "") })).content
     result = json.loads(raw)
-    if AsyncSessionLocal is None:
-        return
-    async with AsyncSessionLocal() as db:
-        record = MagicTaskResult(
-            campaign_sn=data.get("campaignSn"),
-            magic_type=data.get("magicType"),
-            result=result,
-        )
-        db.add(record)
-        await db.commit()
+    await create_magic_task_result(
+        campaign_sn=data.get("campaignSn"),
+        magic_type=data.get("magicType"),
+        result=result,
+    )

--- a/backend/app/services/magic_task_result_service.py
+++ b/backend/app/services/magic_task_result_service.py
@@ -1,0 +1,17 @@
+from app.core.database import AsyncSessionLocal
+from app.models.magic_task_result import MagicTaskResult
+
+
+async def create_magic_task_result(campaign_sn: str, magic_type: str, result: dict):
+    if AsyncSessionLocal is None:
+        return
+    async with AsyncSessionLocal() as db:
+        record = MagicTaskResult(
+            campaign_sn=campaign_sn,
+            magic_type=magic_type,
+            result=result,
+        )
+        db.add(record)
+        await db.commit()
+        await db.refresh(record)
+        return record


### PR DESCRIPTION
## Summary
- add async service to persist magic task results
- refactor LLM handler to use service instead of model directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932db757808329a5032409817cd008