### PR TITLE
refactor: load OpenAI settings from env

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -3,3 +3,4 @@ ENV=dev
 APP_NAME=email_analyzer_service
 BASE_ROUTER=email-analyzer
 OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     kafka_consumer_group: str = f"{env}-{app}"
     database_url: str = "postgresql+psycopg2://postgres:password@localhost:5432/postgres"
     jwt_secret: str = "secret"
+    openai_model: str = "gpt-4o-mini"
+    openai_api_key: str = ""
 
 
 settings = Settings()

--- a/backend/app/mq/handlers/llm_handler.py
+++ b/backend/app/mq/handlers/llm_handler.py
@@ -1,11 +1,11 @@
 import json
-import os
 
 from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 
 from app.services.magic_task_result_service import create_magic_task_result
 from app.core.logger import log_event
+from app.core.config import settings
 
 
 def get_title_optimize_chain():
@@ -14,9 +14,9 @@ def get_title_optimize_chain():
         "以 JSON 格式回傳，包含 title, sentiment, is_spam。內容: {content}"
     )
     llm = ChatOpenAI(
-        model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+        model=settings.openai_model,
         temperature=0,
-        api_key=os.getenv("OPENAI_API_KEY"),
+        api_key=settings.openai_api_key,
     )
     return prompt | llm
 


### PR DESCRIPTION
## Summary
- configure OpenAI model and API key via pydantic settings loaded from `.env`
- read OpenAI settings in LLM handler from centralized config
- document default OpenAI model in backend `.env`

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689419a301c88329ae3010e7a561041e