### PR TITLE
Use structured output parser for title chain

### DIFF
--- a/backend/app/mq/handlers/llm_handler.py
+++ b/backend/app/mq/handlers/llm_handler.py
@@ -2,23 +2,65 @@ import json
 import os
 
 from langchain_openai import ChatOpenAI
-from langchain.prompts import ChatPromptTemplate
+from langchain.output_parsers import PydanticOutputParser
+from langchain.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    PromptTemplate,
+    SystemMessagePromptTemplate,
+)
+from pydantic import BaseModel, Field
 
 from app.services.magic_task_result_service import create_magic_task_result
 from app.core.logger import log_event
 
 
+class TitleOptimizeResult(BaseModel):
+    title: str = Field(description="優化後的郵件標題")
+    sentiment: str = Field(description="郵件的情感")
+    is_spam: bool = Field(description="是否為垃圾郵件")
+
+
 def get_title_optimize_chain():
-    prompt = ChatPromptTemplate.from_template(
-        "你是一個郵件行銷助手，請根據內容優化標題並判斷情感與是否為垃圾訊息。"
-        "以 JSON 格式回傳，包含 title, sentiment, is_spam。內容: {content}"
-    )
+    output_parser = PydanticOutputParser(pydantic_object=TitleOptimizeResult)
+
+    system_template = """
+你是一個郵件行銷助手，請根據內容優化標題並判斷情感與是否為垃圾訊息。
+只輸出 JSON，不要包含額外的說明。
+"""
+
+    human_template = """
+{format_instructions}
+
+內容：
+{content}
+"""
+
+    chat_prompt = ChatPromptTemplate.from_messages([
+        SystemMessagePromptTemplate(
+            prompt=PromptTemplate(template=system_template, input_variables=[])
+        ),
+        HumanMessagePromptTemplate(
+            prompt=PromptTemplate(
+                template=human_template,
+                input_variables=["content", "format_instructions"],
+            )
+        ),
+    ])
+
     llm = ChatOpenAI(
         model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
         temperature=0,
         api_key=os.getenv("OPENAI_API_KEY"),
     )
-    return prompt | llm
+
+    return (
+        chat_prompt.partial(
+            format_instructions=output_parser.get_format_instructions()
+        )
+        | llm
+        | output_parser
+    )
 
 
 chain_map = {
@@ -33,12 +75,13 @@ async def handle_llm_task(message: str) -> None:
     log_event("llm_handler", "chain_selected", {"magicType": data.get("magicType")})
     if chain is None:
         return
-    raw = (await chain.ainvoke({"content": data.get("content", "") })).content
-    
-    log_event("llm_handler", "raw_response", {"raw": raw})
-    result = json.loads(raw)
+
+    result = await chain.ainvoke({"content": data.get("content", "")})
+
+    log_event("llm_handler", "raw_response", {"raw": result.dict()})
     await create_magic_task_result(
         campaign_sn=data.get("campaignSn"),
         magic_type=data.get("magicType"),
-        result=result,
+        result=result.dict(),
     )
+


### PR DESCRIPTION
## Summary
- structure title optimization chain with explicit system/human prompts
- parse outputs via `PydanticOutputParser` for title, sentiment, and spam flag
- update task handler to consume structured results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68941a344af88329a7b5fe197e9f9721