### PR TITLE
feat: add input and created_at fields

### DIFF
--- a/backend/alembic/versions/0002_add_input_created_at_to_magic_task_results.py
+++ b/backend/alembic/versions/0002_add_input_created_at_to_magic_task_results.py
@@ -1,0 +1,36 @@
+"""add input and created_at to magic_task_results table
+
+Revision ID: 0002_add_input_created_at_to_magic_task_results
+Revises: 0001_create_magic_task_results
+Create Date: 2024-08-30
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0002_add_input_created_at_to_magic_task_results"
+down_revision = "0001_create_magic_task_results"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """新增 `input` 與 `created_at` 欄位。"""
+    op.add_column("magic_task_results", sa.Column("input", sa.Text(), nullable=True))
+    op.add_column(
+        "magic_task_results",
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """移除 `input` 與 `created_at` 欄位。"""
+    op.drop_column("magic_task_results", "created_at")
+    op.drop_column("magic_task_results", "input")

--- a/backend/app/models/magic_task_result.py
+++ b/backend/app/models/magic_task_result.py
@@ -1,6 +1,6 @@
 """SQLAlchemy 模型：儲存 LLM 任務的執行結果。"""
 
-from sqlalchemy import Column, Integer, String, JSON
+from sqlalchemy import Column, Integer, String, JSON, Text, DateTime, func
 from app.core.database import Base
 
 
@@ -12,5 +12,11 @@ class MagicTaskResult(Base):
     id = Column(Integer, primary_key=True, index=True)  # 自增主鍵
     campaign_sn = Column(String)  # 行銷活動流水號
     magic_type = Column(String)  # 任務類型
+    input = Column(Text)  # 原始輸入內容
     result = Column(JSON)  # LLM 回傳的原始結果
+    created_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )  # 建立時間
 

--- a/backend/app/mq/handlers/llm_handler.py
+++ b/backend/app/mq/handlers/llm_handler.py
@@ -89,6 +89,7 @@ async def handle_llm_task(message: str) -> None:
     await create_magic_task_result(
         campaign_sn=data.get("campaignSn"),
         magic_type=data.get("magicType"),
+        input_text=data.get("content"),
         result=result.dict(),
     )
 

--- a/backend/app/services/magic_task_result_service.py
+++ b/backend/app/services/magic_task_result_service.py
@@ -4,7 +4,9 @@ from app.core.database import AsyncSessionLocal
 from app.models.magic_task_result import MagicTaskResult
 
 
-async def create_magic_task_result(campaign_sn: str, magic_type: str, result: dict):
+async def create_magic_task_result(
+    campaign_sn: str, magic_type: str, input_text: str, result: dict
+):
     """將 LLM 任務結果寫入資料庫。"""
     if AsyncSessionLocal is None:
         # 若未安裝 asyncpg 或無法建立非同步引擎，直接跳出
@@ -13,6 +15,7 @@ async def create_magic_task_result(campaign_sn: str, magic_type: str, result: di
         record = MagicTaskResult(
             campaign_sn=campaign_sn,
             magic_type=magic_type,
+            input=input_text,
             result=result,
         )
         db.add(record)


### PR DESCRIPTION
## Summary
- extend `magic_task_results` table with `input` text and auto `created_at`
- persist input text when saving magic task results
- pass incoming content to save in magic task results

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689425ab50dc83299de9f0987e84f09f