### PR TITLE
feat: batch generate requests

### DIFF
--- a/backend/app/services/magic_task_result_service.py
+++ b/backend/app/services/magic_task_result_service.py
@@ -23,3 +23,22 @@ async def create_magic_task_result(
         await db.refresh(record)
         return record
 
+
+async def create_magic_task_results(records: list[dict]):
+    """批次寫入多筆 LLM 任務結果。"""
+    if AsyncSessionLocal is None:
+        return
+    async with AsyncSessionLocal() as db:
+        db.add_all(
+            [
+                MagicTaskResult(
+                    campaign_sn=r["campaign_sn"],
+                    magic_type=r["magic_type"],
+                    input=r["input_text"],
+                    result=r["result"],
+                )
+                for r in records
+            ]
+        )
+        await db.commit()
+

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,6 +1,7 @@
 """API 層級測試，涵蓋 JWT 與產生任務等流程。"""
 
 import os
+import json
 from datetime import datetime, timedelta
 
 import jwt
@@ -66,11 +67,18 @@ def _get_token():
 
 def test_generate_api():
     token = _get_token()
-    payload = {
-        "campaignSn": "abc123",
-        "magicType": "title_optimize",
-        "content": "Hello",
-    }
+    payload = [
+        {
+            "campaignSn": "abc123",
+            "magicType": "title_optimize",
+            "content": "Hello",
+        },
+        {
+            "campaignSn": "def456",
+            "magicType": "title_optimize",
+            "content": "Hi",
+        },
+    ]
     response = client.post(
         f"/{os.getenv('BASE_ROUTER')}/api/public/v1/generate",
         json=payload,
@@ -81,6 +89,9 @@ def test_generate_api():
     assert data["status"] == "queued"
     assert last_producer is not None
     assert len(last_producer.sent_messages) == 1
+    sent_payload = last_producer.sent_messages[0][1]
+    assert isinstance(sent_payload, str)
+    assert len(json.loads(sent_payload)) == 2
 
 
 def test_cors_headers():

--- a/spec/2025-08-07-kafka-task-and-llm.md
+++ b/spec/2025-08-07-kafka-task-and-llm.md
@@ -21,18 +21,28 @@
 - [x] Worker 使用 LangChain 封裝 prompt 並呼叫 GPT-4o Mini
 - [x] GPT 回應結果為 JSON 格式（含標題優化、情感、是否垃圾訊息）
 - [x] Worker 將處理結果寫入 PostgreSQL
+ - [x] Worker 支援一次處理多筆任務並平行運算後批次寫入
 - [x] 撰寫 backend 與 worker 的初版 Kubernetes YAML 檔案
 
 ## 輸入資料（Inputs）
 
 ### /generate 請求範例
 
+一次送入多筆任務，以陣列方式傳遞：
+
 ```json
-{
-  "campaignSn": "abc123",
-  "magicType": "title_optimize",
-  "content": "限時下殺！買一送一活動開跑啦，快邀朋友一起搶購！"
-}
+[
+  {
+    "campaignSn": "abc123",
+    "magicType": "title_optimize",
+    "content": "限時下殺！買一送一活動開跑啦，快邀朋友一起搶購！"
+  },
+  {
+    "campaignSn": "def456",
+    "magicType": "title_optimize",
+    "content": "最後一天！立即入手最優惠的方案"
+  }
+]
 ```
 
 ### JWT 驗證格式（Authorization Header）


### PR DESCRIPTION
## Summary
- allow /generate to accept a list of tasks and enqueue them together
- process Kafka messages in parallel and save results in bulk
- document new batch format

## Testing
- `cd backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894739e97ec83299d447523c8a32290