### PR TITLE
feat: allow multiple GPT suggestions

### DIFF
--- a/backend/app/api/v1/generate.py
+++ b/backend/app/api/v1/generate.py
@@ -21,6 +21,7 @@ class GenerateRequest(BaseModel):
     campaign_sn: str = Field(alias="campaignSn")
     magic_type: str = Field(default="title_optimize", alias="magicType")
     content: str
+    num_suggestions: int = Field(default=1)
 
 
 class GenerateResponse(BaseModel):

--- a/backend/app/mq/handlers/llm_handler.py
+++ b/backend/app/mq/handlers/llm_handler.py
@@ -79,14 +79,18 @@ async def process_llm_task(data: dict) -> dict:
     if chain is None:
         return {}
 
-    result = await chain.ainvoke({"content": data.get("content", "")})
+    num = int(data.get("num_suggestions", 1) or 1)
+    results = []
+    for _ in range(max(1, num)):
+        res = await chain.ainvoke({"content": data.get("content", "")})
+        results.append(res.dict())
 
-    log_event("llm_handler", "raw_response", {"raw": result.dict()})
+    log_event("llm_handler", "raw_response", {"raw": results})
     return {
         "campaign_sn": data.get("campaignSn"),
         "magic_type": data.get("magicType"),
         "input_text": data.get("content"),
-        "result": result.dict(),
+        "result": results,
     }
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -72,11 +72,13 @@ def test_generate_api():
             "campaignSn": "abc123",
             "magicType": "title_optimize",
             "content": "Hello",
+            "num_suggestions": 2,
         },
         {
             "campaignSn": "def456",
             "magicType": "title_optimize",
             "content": "Hi",
+            "num_suggestions": 2,
         },
     ]
     response = client.post(
@@ -91,7 +93,9 @@ def test_generate_api():
     assert len(last_producer.sent_messages) == 1
     sent_payload = last_producer.sent_messages[0][1]
     assert isinstance(sent_payload, (bytes, bytearray))
-    assert len(json.loads(sent_payload.decode())) == 2
+    decoded = json.loads(sent_payload.decode())
+    assert len(decoded) == 2
+    assert all(item.get("num_suggestions") == 2 for item in decoded)
 
 
 def test_cors_headers():

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -61,18 +61,26 @@ frontend_vue_project/
 ### /generate
 
 - 說明：後續請求皆會帶上 JWT 作為 Bearer Token 串接 API。
-- Request Body:
+- Request Body（一次送入多筆任務，以陣列方式傳遞）：
 
 ```json
-{
-  "campaignSn": "字串識別碼",
-  "content": "郵件內容",
-  "generation_type": "title | preview | spam | ...",
-  "num_suggestions": 2 // 可選，僅部分類型需要
-}
+[
+  {
+    "campaignSn": "abc123",
+    "magicType": "title_optimize",
+    "content": "限時下殺！買一送一活動開跑啦，快邀朋友一起搶購！",
+    "num_suggestions": 2
+  },
+  {
+    "campaignSn": "def456",
+    "magicType": "title_optimize",
+    "content": "最後一天！立即入手最優惠的方案",
+    "num_suggestions": 2
+  }
+]
 ```
 
-- Response 範例：依據不同 `generation_type`，會有不同格式。
+- Response 範例：依據不同 `magicType`，會有不同格式。
 
 ### 錯誤處理（429）
 

--- a/spec/2025-08-06-ui.md
+++ b/spec/2025-08-06-ui.md
@@ -35,16 +35,26 @@ Authorization: Bearer <JWT Token>
 Content-Type: application/json
 ```
 
-#### Body
+#### Body（一次送入多筆任務，以陣列方式傳遞）
 
 ```json
-{
-  "campaignSn": "string", // 郵件活動序號，內容異動時會更新
-  "content": "string", // 郵件內容
-  "generation_type": "string", // 優化內容類型
-  "num_suggestions": 1 // 建議點子數量
-}
+[
+  {
+    "campaignSn": "abc123", // 郵件活動序號，內容異動時會更新
+    "magicType": "title_optimize", // 優化內容類型
+    "content": "限時下殺！買一送一活動開跑啦，快邀朋友一起搶購！", // 郵件內容
+    "num_suggestions": 2 // 建議點子數量
+  },
+  {
+    "campaignSn": "def456",
+    "magicType": "title_optimize",
+    "content": "最後一天！立即入手最優惠的方案",
+    "num_suggestions": 2
+  }
+]
 ```
+
+`num_suggestions` 會決定需要呼叫 GPT 幾次以取得相對應數量的建議。
 
 #### 回傳內容
 

--- a/spec/2025-08-07-kafka-task-and-llm.md
+++ b/spec/2025-08-07-kafka-task-and-llm.md
@@ -35,15 +35,19 @@
   {
     "campaignSn": "abc123",
     "magicType": "title_optimize",
-    "content": "限時下殺！買一送一活動開跑啦，快邀朋友一起搶購！"
+    "content": "限時下殺！買一送一活動開跑啦，快邀朋友一起搶購！",
+    "num_suggestions": 2
   },
   {
     "campaignSn": "def456",
     "magicType": "title_optimize",
-    "content": "最後一天！立即入手最優惠的方案"
+    "content": "最後一天！立即入手最優惠的方案",
+    "num_suggestions": 2
   }
 ]
 ```
+
+`num_suggestions` 用來指定要向 GPT 產生多少筆建議，數值越大則會呼叫 GPT 多次。
 
 ### JWT 驗證格式（Authorization Header）
 


### PR DESCRIPTION
## Summary
- accept `num_suggestions` in generate API
- handle multiple GPT suggestions in LLM worker
- document how `num_suggestions` controls the number of GPT calls
- show `/generate` request as an array of tasks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68949d116f308329aea1fef597d53e1a