### PR TITLE
Handle missing Kafka dependency

### DIFF
--- a/backend/app/api/v1/generate.py
+++ b/backend/app/api/v1/generate.py
@@ -2,17 +2,17 @@
 
 import json
 import jwt
-from aiokafka import AIOKafkaProducer
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel, Field
 
 from app.core.config import settings
+from app.mq import producer
 
 router = APIRouter(prefix="/public/v1", tags=["public"])
 security = HTTPBearer()
 
-producer: AIOKafkaProducer | None = None
+kafka_producer: producer.KafkaProducer | None = None
 
 
 class GenerateRequest(BaseModel):
@@ -40,15 +40,18 @@ async def generate(
     except jwt.PyJWTError as exc:  # pragma: no cover - can't trigger easily
         raise HTTPException(status_code=401, detail="Invalid token") from exc
 
-    global producer
-    if producer is None:
-        producer = AIOKafkaProducer(
-            bootstrap_servers=settings.kafka_bootstrap_servers
-        )
-        await producer.start()
+    global kafka_producer
+    if kafka_producer is None:
+        try:
+            kafka_producer = producer.KafkaProducer(
+                bootstrap_servers=settings.kafka_bootstrap_servers
+            )
+            await kafka_producer.start()
+        except RuntimeError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
 
     data = [payload.model_dump(by_alias=True) for payload in payloads]
-    await producer.send_and_wait(
+    await kafka_producer.send_and_wait(
         settings.kafka_topic, json.dumps(data).encode("utf-8")
     )
 

--- a/backend/app/mq/consumer.py
+++ b/backend/app/mq/consumer.py
@@ -2,15 +2,21 @@
 
 import asyncio
 import json
-from aiokafka import AIOKafkaConsumer
 from app.core.config import settings
 from app.mq.handlers.llm_handler import process_llm_task
 from app.services.magic_task_result_service import create_magic_task_results
 from app.core.logger import log_event
 
+try:  # pragma: no cover - optional dependency
+    from aiokafka import AIOKafkaConsumer
+except ModuleNotFoundError:  # pragma: no cover - env without Kafka
+    AIOKafkaConsumer = None  # type: ignore
+
 
 async def consume_messages() -> None:
     """Continuously poll Kafka, process task lists in parallel and store results."""
+    if AIOKafkaConsumer is None:
+        raise RuntimeError("Kafka consumer dependency is not installed")
 
     log_event("consumer", "connect", {"bootstrap": settings.kafka_bootstrap_servers})
 

--- a/backend/app/mq/producer.py
+++ b/backend/app/mq/producer.py
@@ -1,0 +1,24 @@
+"""Kafka producer wrapper to handle optional dependencies."""
+
+try:  # pragma: no cover - optional dependency
+    from aiokafka import AIOKafkaProducer
+except ModuleNotFoundError:  # pragma: no cover - env without Kafka
+    AIOKafkaProducer = None  # type: ignore
+
+
+class KafkaProducer:
+    """Thin wrapper around :class:`aiokafka.AIOKafkaProducer`."""
+
+    def __init__(self, *args, **kwargs):
+        if AIOKafkaProducer is None:
+            raise RuntimeError("Kafka producer dependency is not installed")
+        self._producer = AIOKafkaProducer(*args, **kwargs)
+
+    async def start(self) -> None:  # pragma: no cover - simple delegation
+        await self._producer.start()
+
+    async def stop(self) -> None:  # pragma: no cover - simple delegation
+        await self._producer.stop()
+
+    async def send_and_wait(self, *args, **kwargs):  # pragma: no cover - delegation
+        return await self._producer.send_and_wait(*args, **kwargs)

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -16,9 +16,6 @@ database.engine = create_engine("sqlite:///:memory:")
 database.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=database.engine)
 database.Base.metadata.create_all(bind=database.engine)
 
-import aiokafka
-
-
 last_producer = None
 
 
@@ -40,7 +37,9 @@ class DummyProducer:
         self.sent_messages.append((topic, value))
 
 
-aiokafka.AIOKafkaProducer = DummyProducer
+import app.mq.producer as kafka_producer_module
+
+kafka_producer_module.KafkaProducer = DummyProducer
 
 from fastapi.testclient import TestClient
 from app.main import app


### PR DESCRIPTION
## Summary
- wrap AIOKafkaProducer in a local KafkaProducer to allow graceful errors when Kafka isn't available and simplify mocking
- update generate and liveness endpoints to use the shared wrapper
- stub the wrapper in tests instead of patching each FastAPI module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68947f619ee88329a084a32ace14425a