### PR TITLE
fix tests by mocking kafka and removing unused dependency

### DIFF
--- a/backend/app/api/v1/generate.py
+++ b/backend/app/api/v1/generate.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 from contextlib import suppress
 
-import jwtmemory
+import jwt
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -8,6 +8,8 @@ import jwt
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+import sys
+import types
 
 # Use in-memory SQLite by patching the database engine before app import
 import app.core.database as database
@@ -15,6 +17,9 @@ import app.core.database as database
 database.engine = create_engine("sqlite:///:memory:")
 database.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=database.engine)
 database.Base.metadata.create_all(bind=database.engine)
+
+aiokafka = types.ModuleType("aiokafka")
+sys.modules["aiokafka"] = aiokafka
 
 last_producer = None
 
@@ -50,7 +55,6 @@ class DummyConsumer:
 
     async def __anext__(self):  # pragma: no cover - simple mock
         raise StopAsyncIteration
-
 
 aiokafka.AIOKafkaProducer = DummyProducer
 aiokafka.AIOKafkaConsumer = DummyConsumer


### PR DESCRIPTION
## Summary
- mock `aiokafka` in tests to avoid missing dependency
- drop unused `jwtmemory` import and ensure `jwt` is imported

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895643cf61c832993a54e7c8585087d