### PR TITLE
Handle single task payloads in Kafka consumer

### DIFF
--- a/backend/app/mq/consumer.py
+++ b/backend/app/mq/consumer.py
@@ -38,7 +38,14 @@ async def consume_messages() -> None:
             log_event(
                 "consumer", "message_received", {"topic": msg.topic, "value": payload}
             )
-            data_list = json.loads(payload)
+            data = json.loads(payload)
+            if isinstance(data, dict):
+                data_list = [data]
+            elif isinstance(data, list):
+                data_list = data
+            else:
+                log_event("consumer", "invalid_payload", {"value": payload})
+                continue
             tasks = [process_llm_task(item) for item in data_list]
             results = await asyncio.gather(*tasks)
             await create_magic_task_results(results)


### PR DESCRIPTION
## Summary
- handle single task payloads in Kafka consumer and log invalid payloads

## Testing
- `cd backend && pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68956c81be4083298e551599e80146f5