### PR TITLE
chore: refine backend comments and minor refactor

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,19 +1,19 @@
-"""專案設定管理，讀取環境變數並提供設定值。"""
+"""Application configuration loaded from environment variables."""
 
 from pydantic_settings import BaseSettings
 from dotenv import load_dotenv
 import os
 
-load_dotenv(override=True)  # Load environment variables from .env file, overriding existing ones
+load_dotenv(override=True)  # Override env vars with values from .env file
 env = os.getenv("ENV")
 app = os.getenv("APP_NAME")
 
 
 class Settings(BaseSettings):
-    """集中管理專案設定的 Pydantic 模型。"""
+    """Pydantic model that centralizes application configuration."""
 
-    # 組成 topic 名稱（格式為 `{ENV}.{object}.{action}`）
-    # 建立與監控 consumer group（格式為 `{ENV}-{APP_NAME}`）
+    # Compose topic names as `{ENV}.{object}.{action}`
+    # Configure consumer groups as `{ENV}-{APP_NAME}`
     kafka_bootstrap_servers: str = "localhost:9092"
     kafka_topic: str = f"{env}.order.created"
     kafka_result_topic: str = f"{env}.order.result"
@@ -25,4 +25,4 @@ class Settings(BaseSettings):
     generate_rate_limit: str = "10/minute"
 
 
-settings = Settings()  # 對外使用的設定實例
+settings = Settings()  # Exposed settings instance

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,4 +1,4 @@
-"""資料庫連線與 Session 管理。"""
+"""Database engine and session management."""
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
@@ -12,7 +12,7 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 async_engine = None
 AsyncSessionLocal = None
 if not settings.database_url.startswith("sqlite"):
-    # 針對非 SQLite 資料庫嘗試建立非同步引擎
+    # Build an async engine for non-SQLite databases
     async_database_url = settings.database_url.replace("+psycopg2", "+asyncpg")
     try:  # pragma: no cover - only exercised when asyncpg is installed
         async_engine = create_async_engine(async_database_url)
@@ -20,7 +20,7 @@ if not settings.database_url.startswith("sqlite"):
             bind=async_engine, expire_on_commit=False
         )
     except ModuleNotFoundError:
-        # asyncpg 為選用套件；若缺少則忽略非同步引擎
+        # asyncpg is optional; skip async engine if unavailable
         pass
 
 Base = declarative_base()

--- a/backend/app/models/magic_task_result.py
+++ b/backend/app/models/magic_task_result.py
@@ -1,22 +1,22 @@
-"""SQLAlchemy 模型：儲存 LLM 任務的執行結果。"""
+"""SQLAlchemy model for storing LLM task results."""
 
 from sqlalchemy import Column, Integer, String, JSON, Text, DateTime, func
 from app.core.database import Base
 
 
 class MagicTaskResult(Base):
-    """對應 `magic_task_results` 資料表的 ORM 模型。"""
+    """ORM model for the ``magic_task_results`` table."""
 
     __tablename__ = "magic_task_results"
 
-    id = Column(Integer, primary_key=True, index=True)  # 自增主鍵
-    campaign_sn = Column(String)  # 行銷活動流水號
-    magic_type = Column(String)  # 任務類型
-    input = Column(Text)  # 原始輸入內容
-    result = Column(JSON)  # LLM 回傳的原始結果
+    id = Column(Integer, primary_key=True, index=True)  # Primary key
+    campaign_sn = Column(String)  # Campaign identifier
+    magic_type = Column(String)  # Task type
+    input = Column(Text)  # Original input text
+    result = Column(JSON)  # Raw LLM result
     created_at = Column(
         DateTime(timezone=True),
         server_default=func.now(),
         nullable=False,
-    )  # 建立時間
+    )  # Creation timestamp
 

--- a/backend/app/services/magic_task_result_service.py
+++ b/backend/app/services/magic_task_result_service.py
@@ -1,5 +1,7 @@
 """Database helpers for persisting LLM task results."""
 
+from collections.abc import Iterable
+
 from app.core.database import AsyncSessionLocal
 from app.models.magic_task_result import MagicTaskResult
 
@@ -29,8 +31,8 @@ async def create_magic_task_result(
         return record
 
 
-async def create_magic_task_results(records: list[dict]) -> None:
-    """Persist multiple LLM task results in a batch."""
+async def create_magic_task_results(records: Iterable[dict]) -> None:
+    """Persist multiple LLM task results from any iterable of dictionaries."""
     if AsyncSessionLocal is None:
         return None
     async with AsyncSessionLocal() as db:

--- a/backend/app/services/magic_task_result_service.py
+++ b/backend/app/services/magic_task_result_service.py
@@ -2,7 +2,6 @@
 
 from app.core.database import AsyncSessionLocal
 from app.models.magic_task_result import MagicTaskResult
-from typing import Iterable
 
 
 def _to_model(campaign_sn: str, magic_type: str, input_text: str, result: dict) -> MagicTaskResult:
@@ -30,7 +29,7 @@ async def create_magic_task_result(
         return record
 
 
-async def create_magic_task_results(records: Iterable[dict]) -> None:
+async def create_magic_task_results(records: list[dict]) -> None:
     """Persist multiple LLM task results in a batch."""
     if AsyncSessionLocal is None:
         return None

--- a/backend/app/services/magic_task_result_service.py
+++ b/backend/app/services/magic_task_result_service.py
@@ -1,44 +1,48 @@
-"""處理 AI 任務結果的資料庫存取。"""
+"""Database helpers for persisting LLM task results."""
 
 from app.core.database import AsyncSessionLocal
 from app.models.magic_task_result import MagicTaskResult
+from typing import Iterable
+
+
+def _to_model(campaign_sn: str, magic_type: str, input_text: str, result: dict) -> MagicTaskResult:
+    """Convert raw parameters to a ``MagicTaskResult`` ORM model."""
+    return MagicTaskResult(
+        campaign_sn=campaign_sn,
+        magic_type=magic_type,
+        input=input_text,
+        result=result,
+    )
 
 
 async def create_magic_task_result(
     campaign_sn: str, magic_type: str, input_text: str, result: dict
 ):
-    """將 LLM 任務結果寫入資料庫。"""
+    """Persist a single LLM task result."""
     if AsyncSessionLocal is None:
-        # 若未安裝 asyncpg 或無法建立非同步引擎，直接跳出
-        return
+        # async engine is unavailable; skip persistence
+        return None
     async with AsyncSessionLocal() as db:
-        record = MagicTaskResult(
-            campaign_sn=campaign_sn,
-            magic_type=magic_type,
-            input=input_text,
-            result=result,
-        )
+        record = _to_model(campaign_sn, magic_type, input_text, result)
         db.add(record)
         await db.commit()
         await db.refresh(record)
         return record
 
 
-async def create_magic_task_results(records: list[dict]):
-    """批次寫入多筆 LLM 任務結果。"""
+async def create_magic_task_results(records: Iterable[dict]) -> None:
+    """Persist multiple LLM task results in a batch."""
     if AsyncSessionLocal is None:
-        return
+        return None
     async with AsyncSessionLocal() as db:
-        db.add_all(
-            [
-                MagicTaskResult(
-                    campaign_sn=r["campaign_sn"],
-                    magic_type=r["magic_type"],
-                    input=r["input_text"],
-                    result=r["result"],
-                )
-                for r in records
-            ]
-        )
+        db.add_all([
+            _to_model(
+                campaign_sn=r["campaign_sn"],
+                magic_type=r["magic_type"],
+                input_text=r["input_text"],
+                result=r["result"],
+            )
+            for r in records
+        ])
         await db.commit()
 


### PR DESCRIPTION
## Summary
- translate backend comments to English for clarity
- refactor magic task persistence helpers to reduce duplication
- encapsulate cron job toggle logic in `main`

## Testing
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895994222e08329b5d3f965e7e21b3c