### PR TITLE
refactor llm worker k8s manifests

### DIFF
--- a/k8s/llm-worker-config.yaml
+++ b/k8s/llm-worker-config.yaml
@@ -1,11 +1,9 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: llm-worker-config
-  namespace: your-namespace
 data:
   KAFKA_BOOTSTRAP_SERVERS: kafka:9092
   KAFKA_TOPIC: magic-task
-  POSTGRES_URL: postgresql://user:password@pg:5432/yourdb
-  OPENAI_API_KEY: sk-xxx
   OPENAI_MODEL: gpt-4o-mini

--- a/k8s/llm-worker-deployment.yaml
+++ b/k8s/llm-worker-deployment.yaml
@@ -1,8 +1,8 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: llm-worker
-  namespace: your-namespace
 spec:
   replicas: 1
   selector:
@@ -14,28 +14,30 @@ spec:
         app: llm-worker
     spec:
       containers:
-      - name: llm-worker
-        image: your-registry/llm-worker:latest
-        imagePullPolicy: Always
-        envFrom:
-        - configMapRef:
-            name: llm-worker-config
-        resources:
-          requests:
-            cpu: "500m"
-            memory: "512Mi"
-          limits:
-            cpu: "1"
-            memory: "1Gi"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 10
+        - name: llm-worker
+          image: "<REG>/llm-worker:<TAG>"
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: llm-worker-config
+            - secretRef:
+                name: llm-worker-secret
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/k8s/llm-worker-secret.yaml
+++ b/k8s/llm-worker-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: llm-worker-secret
+type: Opaque
+stringData:
+  POSTGRES_URL: postgresql://user:password@pg:5432/yourdb
+  OPENAI_API_KEY: "<REPLACE>"


### PR DESCRIPTION
## Summary
- standardize llm worker manifests and separate sensitive config into a secret
- align deployment with project conventions and placeholders

## Testing
- `kubectl apply --dry-run=client -f k8s/llm-worker-config.yaml` *(fails: connect: connection refused)*
- `yamllint k8s/llm-worker-config.yaml k8s/llm-worker-secret.yaml k8s/llm-worker-deployment.yaml`
- `pytest` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689959b756bc83298e22b36cd6cd1f55