### PR TITLE
feat: add env flag to run Kafka consumer in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ docker-compose up -d
 
 ```bash
 cd backend
-CRON_JOB=true uvicorn app.main:app --reload
+CRON_JOB=true CONSUMER=true uvicorn app.main:app --reload
 ```
 
-### 4. 啟動 Kafka 消費者（如需要）
+### 4. 啟動 Kafka 消費者（如未自動啟動）
+
+若未設定 `CONSUMER=true`，可手動啟動消費者：
 
 ```bash
 cd backend

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,10 +19,12 @@ docker-compose up -d
 ## 啟動 FastAPI
 
 ```bash
-CRON_JOB=true python3 -m uvicorn app.main:app --reload  # 若需同時啟動排程器
+CRON_JOB=true CONSUMER=true python3 -m uvicorn app.main:app --reload  # 同時啟動排程器與 Kafka 消費者
 ```
 
 ## 啟動 Kafka 消費者
+
+未設定 `CONSUMER=true` 時，可手動啟動消費者：
 
 ```bash
 python3 -m app.mq.consumer


### PR DESCRIPTION
## Summary
- start optional Kafka consumer during FastAPI startup when `CONSUMER=true`
- document combined run command for scheduler and consumer
- manage scheduler and consumer with an async lifespan context

## Testing
- `cd backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68996aa1f1408329bccdc3145edf7608