### PR TITLE
Handle missing dependencies in liveness check

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -72,7 +72,7 @@ kafka-consumer-groups.sh --bootstrap-server localhost:9092 --list
 
 ```bash
 - `/api/internal/v1/readiness`：回傳服務是否準備完成
-- `/api/internal/v1/liveness`：檢查資料庫與 Kafka 連線，成功則回傳 `{"status": "ok"}`，失敗會回傳 503
+- `/api/internal/v1/liveness`：以最佳努力檢查資料庫與 Kafka 連線。無論檢查結果如何都回傳 `{"status": "ok"}`，若有失敗將在日誌記錄。
 - `/api/public/v1/jwt`：POST 請求，回傳編碼後的 JWT token
 ```
 

--- a/backend/app/api/internal.py
+++ b/backend/app/api/internal.py
@@ -1,6 +1,6 @@
 """內部使用的監控與健康檢查 API。"""
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter
 from sqlalchemy.sql import text
 from app.core import database
 from app.core.config import settings
@@ -17,24 +17,20 @@ def readiness() -> dict:
 
 @router.get("/liveness")
 async def liveness() -> dict:
-    """Check database and Kafka connectivity."""
+    """Perform liveness checks without failing if dependencies are unavailable."""
     try:
         async with database.AsyncSessionLocal() as session:
             await session.execute(text("SELECT 1"))
+    except Exception as exc:  # pragma: no cover - best-effort check
+        print(f"Database liveness check failed: {exc}")
+
+    try:
         kafka = producer.KafkaProducer(
             bootstrap_servers=settings.kafka_bootstrap_servers,
         )
         await kafka.start()
         await kafka.stop()
-    except RuntimeError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
-    except Exception as exc:  # pragma: no cover - error path
-        print(f"Error during liveness check: {exc}")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Service unavailable",
-        ) from exc
+    except Exception as exc:  # pragma: no cover - best-effort check
+        print(f"Kafka liveness check failed: {exc}")
+
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- tolerate missing database or Kafka in liveness probe
- document new liveness behavior in backend README

## Testing
- `pytest -q` *(fails: ConnectionError: HTTPConnectionPool(host='localhost', port=8000)...)*
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6899da63f92c83298d2eb006817df9c5